### PR TITLE
Fix Selector Initialization Issue When Invoked from Another Module

### DIFF
--- a/R/dressing_room.R
+++ b/R/dressing_room.R
@@ -1250,7 +1250,7 @@ app_creator_feedback_server <- function(id, warning_messages, error_messages, ui
     }
   )
 
-  
+
 
   return(module)
 }

--- a/R/dressing_room.R
+++ b/R/dressing_room.R
@@ -1246,6 +1246,8 @@ app_creator_feedback_server <- function(id, warning_messages, error_messages, ui
         if (length(error_messages()) == 0) res <- append(res, list(ui))
         return(res)
       })
+
+      # See: (ag4hj)
       shiny::outputOptions(output, "ui", suspendWhenHidden = FALSE)
     }
   )

--- a/R/dressing_room.R
+++ b/R/dressing_room.R
@@ -1246,8 +1246,11 @@ app_creator_feedback_server <- function(id, warning_messages, error_messages, ui
         if (length(error_messages()) == 0) res <- append(res, list(ui))
         return(res)
       })
+      shiny::outputOptions(output, "ui", suspendWhenHidden = FALSE)
     }
   )
+
+  
 
   return(module)
 }

--- a/R/mod_patient_profile.R
+++ b/R/mod_patient_profile.R
@@ -85,7 +85,6 @@ mod_patient_profile_server <- function(id, subject_level_dataset, extra_datasets
             )
           )
         }
-        message("PAPO UI")
         return(res)
       })
 
@@ -93,8 +92,7 @@ mod_patient_profile_server <- function(id, subject_level_dataset, extra_datasets
 
       output[["selector"]] <- shiny::renderUI({
         subject_level_dataset <- subject_level_dataset()
-        shiny::req(subject_level_dataset, cancelOutput = TRUE)
-        message("PAPO SELECTOR")
+        shiny::req(subject_level_datas
         shiny::selectInput(ns("patient_selector"),
           label = "Select Patient ID:",
           selected = input[["patient_selector"]],

--- a/R/mod_patient_profile.R
+++ b/R/mod_patient_profile.R
@@ -85,6 +85,7 @@ mod_patient_profile_server <- function(id, subject_level_dataset, extra_datasets
             )
           )
         }
+        message("PAPO UI")
         return(res)
       })
 
@@ -92,7 +93,8 @@ mod_patient_profile_server <- function(id, subject_level_dataset, extra_datasets
 
       output[["selector"]] <- shiny::renderUI({
         subject_level_dataset <- subject_level_dataset()
-        shiny::req(subject_level_datas
+        shiny::req(subject_level_dataset, cancelOutput = TRUE)
+        message("PAPO SELECTOR")
         shiny::selectInput(ns("patient_selector"),
           label = "Select Patient ID:",
           selected = input[["patient_selector"]],

--- a/R/mod_patient_profile.R
+++ b/R/mod_patient_profile.R
@@ -100,8 +100,6 @@ mod_patient_profile_server <- function(id, subject_level_dataset, extra_datasets
         )
       })
 
-      outputOptions(output, "selector", suspendWhenHidden = FALSE)
-
       # change selected patient based on sender_ids
       if (!is.null(sender_ids)) {
         lapply(sender_ids, function(x) {

--- a/R/mod_patient_profile.R
+++ b/R/mod_patient_profile.R
@@ -85,7 +85,6 @@ mod_patient_profile_server <- function(id, subject_level_dataset, extra_datasets
             )
           )
         }
-        message("PAPO UI")
         return(res)
       })
 
@@ -94,7 +93,6 @@ mod_patient_profile_server <- function(id, subject_level_dataset, extra_datasets
       output[["selector"]] <- shiny::renderUI({
         subject_level_dataset <- subject_level_dataset()
         shiny::req(subject_level_dataset, cancelOutput = TRUE)
-        message("PAPO SELECTOR")
         shiny::selectInput(ns("patient_selector"),
           label = "Select Patient ID:",
           selected = input[["patient_selector"]],

--- a/R/mod_patient_profile.R
+++ b/R/mod_patient_profile.R
@@ -91,7 +91,7 @@ mod_patient_profile_server <- function(id, subject_level_dataset, extra_datasets
 
       shiny::outputOptions(output, "ui", suspendWhenHidden = FALSE)
 
-      output[["selector"]] <- shiny::renderUI({        
+      output[["selector"]] <- shiny::renderUI({
         subject_level_dataset <- subject_level_dataset()
         shiny::req(subject_level_dataset, cancelOutput = TRUE)
         message("PAPO SELECTOR")

--- a/R/mod_patient_profile.R
+++ b/R/mod_patient_profile.R
@@ -88,6 +88,9 @@ mod_patient_profile_server <- function(id, subject_level_dataset, extra_datasets
         return(res)
       })
 
+      # (ag4hj): Without these outputOptions the update selector (See: ag4hj) tries to update a selector that is not yet
+      # in the UI. Therefore the update is lost. In practice this means that when using the receiver_ids the first
+      # subjid is lost and the interaction is incorrect.
       shiny::outputOptions(output, "ui", suspendWhenHidden = FALSE)
 
       output[["selector"]] <- shiny::renderUI({
@@ -100,8 +103,10 @@ mod_patient_profile_server <- function(id, subject_level_dataset, extra_datasets
         )
       })
 
+      # See: (ag4hj)
       shiny::outputOptions(output, "selector", suspendWhenHidden = FALSE)
 
+      # See: (ag4hj)
       # change selected patient based on sender_ids
       if (!is.null(sender_ids)) {
         lapply(sender_ids, function(x) {

--- a/R/mod_patient_profile.R
+++ b/R/mod_patient_profile.R
@@ -98,6 +98,8 @@ mod_patient_profile_server <- function(id, subject_level_dataset, extra_datasets
         )
       })
 
+      outputOptions(output, "selector", suspendWhenHidden = FALSE)
+
       # change selected patient based on sender_ids
       if (!is.null(sender_ids)) {
         lapply(sender_ids, function(x) {

--- a/R/mod_patient_profile.R
+++ b/R/mod_patient_profile.R
@@ -88,6 +88,8 @@ mod_patient_profile_server <- function(id, subject_level_dataset, extra_datasets
         return(res)
       })
 
+      outputOptions(output, "ui", suspendWhenHidden = FALSE)
+
       output[["selector"]] <- shiny::renderUI({
         subject_level_dataset <- subject_level_dataset()
         shiny::req(subject_level_dataset, cancelOutput = TRUE)

--- a/R/mod_patient_profile.R
+++ b/R/mod_patient_profile.R
@@ -85,18 +85,24 @@ mod_patient_profile_server <- function(id, subject_level_dataset, extra_datasets
             )
           )
         }
+        message("PAPO UI")
         return(res)
       })
 
-      output[["selector"]] <- shiny::renderUI({
+      shiny::outputOptions(output, "ui", suspendWhenHidden = FALSE)
+
+      output[["selector"]] <- shiny::renderUI({        
         subject_level_dataset <- subject_level_dataset()
         shiny::req(subject_level_dataset, cancelOutput = TRUE)
+        message("PAPO SELECTOR")
         shiny::selectInput(ns("patient_selector"),
           label = "Select Patient ID:",
           selected = input[["patient_selector"]],
           choices = unique(subject_level_dataset[[subjid_var]])
         )
       })
+
+      shiny::outputOptions(output, "selector", suspendWhenHidden = FALSE)
 
       # change selected patient based on sender_ids
       if (!is.null(sender_ids)) {

--- a/R/mod_patient_profile.R
+++ b/R/mod_patient_profile.R
@@ -88,8 +88,6 @@ mod_patient_profile_server <- function(id, subject_level_dataset, extra_datasets
         return(res)
       })
 
-      outputOptions(output, "ui", suspendWhenHidden = FALSE)
-
       output[["selector"]] <- shiny::renderUI({
         subject_level_dataset <- subject_level_dataset()
         shiny::req(subject_level_dataset, cancelOutput = TRUE)


### PR DESCRIPTION
When the selector is invoked from another module, it isn't ready yet, resulting in the selected subjid not being passed correctly.