### PR TITLE
fix app erroring despite early feedback errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dv.papo
 Title: Patient Profile
-Version: 2.0.6-900
+Version: 2.0.7-900
 Date: 2024-08-13
 Authors@R: 
     c(person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# dv.papo 2.0.7-900
+- Fix early error feedback conflict with app errors.
+
 # dv.papo 2.0.6-900
 - Update to provide early error feedback if a sender_id is not available in list of modules.
 

--- a/R/mod_patient_profile.R
+++ b/R/mod_patient_profile.R
@@ -370,24 +370,21 @@ mod_patient_profile <- function(module_id = "",
         return(datasets[plot_dataset_names])
       })
 
-      # filter missing sender_ids so app error doesn't conflict with early error feedback.
-      known_sender_ids <- sender_ids
-      if (!is.null(sender_ids)) {
-        known_sender_ids <- intersect(sender_ids, names(afmm[["module_names"]]))
+      # should run if there are no early feedback errors.
+      if (shiny::isolate(length(fb_err())) < 1) {
+        dv.papo::mod_patient_profile_server(
+          id = module_id,
+          subject_level_dataset = subject_level_dataset,
+          extra_datasets = extra_datasets,
+          subjid_var = subjid_var,
+          sender_ids = lapply(sender_ids, function(x) {
+            shiny::reactive(afmm[["module_output"]]()[[x]])
+          }),
+          summary = summary,
+          listings = listings,
+          plots = plots
+        )
       }
-
-      dv.papo::mod_patient_profile_server(
-        id = module_id,
-        subject_level_dataset = subject_level_dataset,
-        extra_datasets = extra_datasets,
-        subjid_var = subjid_var,
-        sender_ids = lapply(known_sender_ids, function(x) {
-          shiny::reactive(afmm[["module_output"]]()[[x]])
-        }),
-        summary = summary,
-        listings = listings,
-        plots = plots
-      )
     },
 
     # Module ID


### PR DESCRIPTION
This fix checks if errors were caught by check_papo_call before attempting main part of patient profile server. Prevents unnecessary/redundant app errors.

https://biac.kanbanize.com/ctrl_board/128/cards/287583/details/